### PR TITLE
Display window titles together with the application name :window: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ niri-switch implements fast task switching for [niri](https://github.com/YaLTeR/
 
 The main use case is quickly switching between windows located on different displays and/or workspaces.
 
-<img width="577" height="98" alt="image" src="https://github.com/user-attachments/assets/7696337c-70c9-40f5-af96-d92394453def" />
-
+<img width="611" height="96" alt="image" src="https://github.com/user-attachments/assets/c2261156-9ad0-45df-ab25-c6e6964b7dd0" />
 
 ## Project status
 

--- a/src/daemon/gui/style.css
+++ b/src/daemon/gui/style.css
@@ -31,19 +31,28 @@ window-list row:last-child {
     border-bottom-right-radius: var(--default--border-radius);
 }
 
-/* A wrapper around a label with a window name */
+/* A wrapper around an entry in the window list */
 window-item-box {
     /* Padding around the contents to make it more readable */
     padding: 1rem;
 }
 
-/* A label containing a window name */
-window-item-label {
-    /* Add some space between the icon and the label */
-    margin-left: 0.4rem;
+/* A wrapper around labels with app name and title */
+window-item-description {
+    /* Add some space between the icon and the labels */
+    margin-left: 0.5rem;
+}
+
+/* A label with the app name */
+/* window-item-label {} */
+
+/* A label with a title of a window */
+window-item-title {
+    font-size: 12px;
+    color: grey;
 }
 
 /* An application icon next to the label */
 window-item-icon {
-    -gtk-icon-size: 1.3rem;
+    -gtk-icon-size: 1.6rem;
 }

--- a/src/daemon/gui/style.css
+++ b/src/daemon/gui/style.css
@@ -34,13 +34,13 @@ window-list row:last-child {
 /* A wrapper around an entry in the window list */
 window-item-box {
     /* Padding around the contents to make it more readable */
-    padding: 1rem;
+    padding: 0.9rem;
 }
 
 /* A wrapper around labels with app name and title */
 window-item-description {
     /* Add some space between the icon and the labels */
-    margin-left: 0.5rem;
+    margin-left: 0.7rem;
 }
 
 /* A label with the app name */
@@ -48,11 +48,16 @@ window-item-description {
 
 /* A label with a title of a window */
 window-item-title {
-    font-size: 12px;
+    font-size: 11px;
+}
+
+/* Set gray font color for titles that are not selected.
+ * Remove this line if it conflicts with your GTK theme  */
+window-list row:not(:selected) window-item-title {
     color: grey;
 }
 
 /* An application icon next to the label */
 window-item-icon {
-    -gtk-icon-size: 1.6rem;
+    -gtk-icon-size: 1.7rem;
 }

--- a/src/daemon/gui/window_list/mod.rs
+++ b/src/daemon/gui/window_list/mod.rs
@@ -88,6 +88,7 @@ fn get_widow_info_for_niri_window(
 ) -> WindowInfo {
     let store = store.lock().unwrap();
     let app_id = window.app_id.clone().unwrap_or_default();
+    let window_title = window.title.clone().unwrap_or_default();
 
     /* Try to get information about the app that coresponds to the window */
     match store.app_database.get_app_info(&app_id) {
@@ -95,8 +96,8 @@ fn get_widow_info_for_niri_window(
             let icon = app_info
                 .icon
                 .map(|icon| gio::Icon::deserialize(&icon).unwrap());
-            WindowInfo::new(window.id, &app_info.display_name, icon)
+            WindowInfo::new(window.id, &window_title, &app_info.display_name, icon)
         }
-        None => WindowInfo::new(window.id, &app_id, None),
+        None => WindowInfo::new(window.id, &window_title, &app_id, None),
     }
 }

--- a/src/daemon/gui/window_list/window_info/imp.rs
+++ b/src/daemon/gui/window_list/window_info/imp.rs
@@ -12,6 +12,9 @@ pub struct WindowInfo {
     id: Cell<u64>,
 
     #[property(get, set)]
+    title: RefCell<String>,
+
+    #[property(get, set)]
     app_name: RefCell<String>,
 
     #[property(get, set)]

--- a/src/daemon/gui/window_list/window_info/mod.rs
+++ b/src/daemon/gui/window_list/window_info/mod.rs
@@ -7,9 +7,10 @@ glib::wrapper! {
 
 /// GObject for holding information about a window
 impl WindowInfo {
-    pub fn new(id: u64, app_name: &String, app_icon: Option<gio::Icon>) -> Self {
+    pub fn new(id: u64, title: &String, app_name: &String,  app_icon: Option<gio::Icon>) -> Self {
         glib::Object::builder()
             .property("id", id)
+            .property("title", title)
             .property("app_name", app_name)
             .property("app_icon", app_icon)
             .build()

--- a/src/daemon/gui/window_list/window_info/mod.rs
+++ b/src/daemon/gui/window_list/window_info/mod.rs
@@ -7,7 +7,7 @@ glib::wrapper! {
 
 /// GObject for holding information about a window
 impl WindowInfo {
-    pub fn new(id: u64, title: &String, app_name: &String,  app_icon: Option<gio::Icon>) -> Self {
+    pub fn new(id: u64, title: &String, app_name: &String, app_icon: Option<gio::Icon>) -> Self {
         glib::Object::builder()
             .property("id", id)
             .property("title", title)

--- a/src/daemon/gui/window_list/window_item/imp.rs
+++ b/src/daemon/gui/window_list/window_item/imp.rs
@@ -9,6 +9,9 @@ use gtk4::subclass::prelude::*;
 #[template(resource = "/org/kikibouba/niriswitch/window_list/window_item/window_item.ui")]
 pub struct WindowItem {
     #[template_child]
+    pub app_name: TemplateChild<gtk4::Label>,
+
+    #[template_child]
     pub title: TemplateChild<gtk4::Label>,
 
     #[template_child]

--- a/src/daemon/gui/window_list/window_item/mod.rs
+++ b/src/daemon/gui/window_list/window_item/mod.rs
@@ -23,7 +23,8 @@ impl WindowItem {
     pub fn set_window_info(&self, window_info: super::window_info::WindowInfo) {
         let imp = self.imp();
 
-        imp.title.set_label(&window_info.app_name());
+        imp.app_name.set_label(&window_info.app_name());
+        imp.title.set_label(&window_info.title());
 
         match window_info.app_icon() {
             Some(gicon) => {

--- a/src/daemon/gui/window_list/window_item/window_item.ui
+++ b/src/daemon/gui/window_list/window_item/window_item.ui
@@ -15,6 +15,8 @@
         <child>
           <object class="GtkLabel" id="app_name">
             <property name="css-name">window-item-label</property>
+            <property name="xalign">0</property>
+            <property name="width-chars">5</property>
           </object>
         </child>
         <child>

--- a/src/daemon/gui/window_list/window_item/window_item.ui
+++ b/src/daemon/gui/window_list/window_item/window_item.ui
@@ -9,8 +9,23 @@
       </object>
     </child>
     <child>
-      <object class="GtkLabel" id="title">
-        <property name="css-name">window-item-label</property>
+      <object class="GtkBox">
+        <property name="css-name">window-item-description</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel" id="app_name">
+            <property name="css-name">window-item-label</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="title">
+            <property name="css-name">window-item-title</property>
+            <property name="ellipsize">end</property>
+            <property name="xalign">0</property>
+            <!-- Hack to help with item width calculation for ListView -->
+            <property name="max-width-chars">1</property>
+          </object>
+        </child>
       </object>
     </child>
   </template>

--- a/src/daemon/gui/window_list/window_item/window_item.ui
+++ b/src/daemon/gui/window_list/window_item/window_item.ui
@@ -16,7 +16,7 @@
           <object class="GtkLabel" id="app_name">
             <property name="css-name">window-item-label</property>
             <property name="xalign">0</property>
-            <property name="width-chars">5</property>
+            <property name="width-chars">7</property>
           </object>
         </child>
         <child>


### PR DESCRIPTION
Display window titles together with the application name to be able to tell apart windows from the same application.