### PR TITLE
Move backwards in the windows list with Alt+Shift+Tab :back: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ After opening the overlay (e.g. via Alt + Tab), you can move around with arrow k
 
 Reapeted calls to niri-switch will also advance the selection.
 
+> [!NOTE]
+> **To enable switching to the *previous* window, you can bind an additional shortcut in your niri config using the `--previous` flag.**
+
+### Customizing Backward Navigation
+
+To enable switching to the **previous** window in the overlay (similar to `Alt+Shift+Tab` in other environments), add the following line to the `binds` section of your niri config (`~/.config/niri/config.kdl`):
+
+```kdl
+binds {
+    Alt+Tab { spawn "niri-switch"; }
+    // Add this line for backward navigation
+    Alt+Shift+Tab { spawn "niri-switch" "--previous"; }
+}
+```
+
 ## Default themes
 
 niri-switch is based on GTK4 and will use your system's default GTK settings. The config is usually located at `~/.config/gtk-4.0/settings.ini` and can be modified. For example, if you want to use dark theme in niri-switch without any CSS modification, you can add 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # niri-switch - A niri task switcher
 
-niri-switch implements fast task switching for [niri](https://github.com/YaLTeR/niri) compositor. It aims to provide functionality similar to Alt-Tab known from Windows, Gnome, KDE Plasma and many other desktop environments.
+niri-switch implements fast task switching for the [niri](https://github.com/YaLTeR/niri) compositor. It aims to provide functionality similar to the Alt-Tab known from Windows, Gnome, KDE Plasma and many other desktop environments.
 
 The main use case is quickly switching between windows located on different displays and/or workspaces.
 
@@ -9,14 +9,14 @@ The main use case is quickly switching between windows located on different disp
 
 ## Project status
 
-niri-switch is currently **usable** and quite stable. It is still in early development and requires few features to be completed to actually deliver a good user experience. But anyone is welcome to play around with it and provide much appreciated feedback.
+niri-switch is currently **usable** and quite stable. It is still in early development and requires a few features to be completed to actually deliver a good user experience. But anyone is welcome to play around with it and provide much appreciated feedback.
 
 ## Dependencies
 
 * `niri` - niri-switch needs a running niri session to connect to it via IPC socket.
 * `gtk4`, `gtk4-layer-shell` - needed to display the graphical interface. The minimal required version of GTK4 is `4.12`.
 
-To install the program you will also need `cargo` - the rust build system. It's usually installed via [rustup](https://www.rust-lang.org/tools/install).
+To install the program you will also need `cargo` - the Rust build system. It's usually installed via [rustup](https://www.rust-lang.org/tools/install).
 
 ## Getting started
 
@@ -24,7 +24,7 @@ Clone the repository and run `cargo install --path ./niri-switch`.
 
 Make sure that `~/.cargo/bin` is in your `$PATH`. You can verify it by running `niri-switch --version`.
 
-Next you need to add following configuration to your niri config at `~/.config/niri/config.kdl`:
+Next you need to add the following configuration to your niri config at `~/.config/niri/config.kdl`:
 ```kdl
 spawn-at-startup "niri-switch-daemon"
 
@@ -34,31 +34,31 @@ binds {
 }
 ```
 
-**After restarting the niri session, niri-switch will be ready to use.**
+**After restarting the niri session, `niri-switch` will be ready to use.**
 > [!NOTE]
 > You can bind the command to any key combination, `Alt+Tab` is just an example.
 
 > [!TIP]
-> Instead of `spawn-at-startup` you can write a custom systemd service for `graphical-session.target` if you want more control over the daemon.
+> Instead of `spawn-at-startup`, you can write a custom systemd service for `graphical-session.target` if you want more control over the daemon.
 
 ## Navigation
 
 After opening the overlay (e.g. via Alt + Tab), you can move around with arrow keys and select a window with Enter. To exit without focusing on any window, press Escape.
 
-Reapeted calls to niri-switch will also advance the selection.
+Repeated calls to `niri-switch` will also advance the selection.
 
-To enable switching to the *previous* window in the overlay (similar to `Alt+Shift+Tab` in other environments), you can bind an additional shortcut in your niri config using the `--previous` option in the `niri-switch` client.
+To enable switching to the previous window (similar to `Alt+Shift+Tab` in other environments), add another keybinding to your `niri` config using the `--previous` option.
 
 ```kdl
 binds {
     // Append this line to the existing binds section
-    Alt+Shift+Tab { spawn "niri-switch" "--previous"; }
+    Alt+Shft+Tab { spawn "niri-switch" "--previous"; }
 }
 ```
 
 ## Default themes
 
-niri-switch is based on GTK4 and will use your system's default GTK settings. The config is usually located at `~/.config/gtk-4.0/settings.ini` and can be modified. For example, if you want to use dark theme in niri-switch without any CSS modification, you can add 
+niri-switch is based on GTK4 and will use your system's default GTK settings. The config is usually located at `~/.config/gtk-4.0/settings.ini` and can be modified. For example, if you want to use a dark theme in `niri-switch` without any CSS modification, you can add 
 ```
 [Settings]
 gtk-application-prefer-dark-theme = true
@@ -67,20 +67,20 @@ to the `settings.ini` file (this will have a global effect). Or run the `niri-sw
 
 ## Customization
 
-You can customize the look by providing custom `~/.config/niri-switch/style.css` file. The default configuration is located in `src/daemon/gui/style.css`, you can copy and modify it.
+You can customize the look by providing custom `~/.config/niri-switch/style.css` file. The default configuration is located in `src/daemon/gui/style.css`. You can copy and modify it.
 
-To examine the CSS classes and the widget hierarchy you can run the daemon with debug flag: `GTK_DEBUG=interactive niri-switch-daemon` and play around in the inspector.
+To examine the CSS classes and the widget hierarchy, you can run the daemon with debug flag: `GTK_DEBUG=interactive niri-switch-daemon` and play around in the inspector.
 
-GTK supports only a specific subset of CSS properties, you can learn more about it in GTK [documentation](https://docs.gtk.org/gtk4/css-properties.html).
+GTK supports only a specific subset of CSS properties. You can learn more about it in GTK [documentation](https://docs.gtk.org/gtk4/css-properties.html).
 
 The configuration is loaded at the daemon startup in this order:
 
 * `$XDG_CONFIG_HOME/niri-switch/style.css` - if the environment variable is set and file exists.
 * `$HOME/.config/niri-switch/style.css` - if the above does not exist or environment variable is not set.
-* Embeded `src/daemon/gui/style.css` - if none of the above exist or needed variables are not set.
+* Embedded `src/daemon/gui/style.css` - if none of the above exist or required variables are not set.
 
 ## Resources
 
-Very useful materials when working with GTK4 and zbus in Rust:
+Some **very** useful materials when working with GTK4 and zbus in Rust:
 * [GUI development with Rust and GTK 4](https://gtk-rs.org/gtk4-rs/stable/latest/book/)
 * [zbus: D-Bus for Rust made easy](https://dbus2.github.io/zbus/)

--- a/README.md
+++ b/README.md
@@ -47,17 +47,11 @@ After opening the overlay (e.g. via Alt + Tab), you can move around with arrow k
 
 Reapeted calls to niri-switch will also advance the selection.
 
-> [!NOTE]
-> **To enable switching to the *previous* window, you can bind an additional shortcut in your niri config using the `--previous` flag.**
-
-### Customizing Backward Navigation
-
-To enable switching to the **previous** window in the overlay (similar to `Alt+Shift+Tab` in other environments), add the following line to the `binds` section of your niri config (`~/.config/niri/config.kdl`):
+To enable switching to the *previous* window in the overlay (similar to `Alt+Shift+Tab` in other environments), you can bind an additional shortcut in your niri config using the `--previous` option in the `niri-switch` client.
 
 ```kdl
 binds {
-    Alt+Tab { spawn "niri-switch"; }
-    // Add this line for backward navigation
+    // Append this line to the existing binds section
     Alt+Shift+Tab { spawn "niri-switch" "--previous"; }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ binds {
 }
 ```
 
-**After restarting the niri session, `niri-switch` will be ready to use.**
+**After restarting the niri session, niri-switch will be ready to use.**
 > [!NOTE]
 > You can bind the command to any key combination, `Alt+Tab` is just an example.
 
@@ -58,7 +58,7 @@ binds {
 
 ## Default themes
 
-niri-switch is based on GTK4 and will use your system's default GTK settings. The config is usually located at `~/.config/gtk-4.0/settings.ini` and can be modified. For example, if you want to use a dark theme in `niri-switch` without any CSS modification, you can add 
+niri-switch is based on GTK4 and will use your system's default GTK settings. The config is usually located at `~/.config/gtk-4.0/settings.ini` and can be modified. For example, if you want to use a dark theme in niri-switch without any CSS modification, you can add 
 ```
 [Settings]
 gtk-application-prefer-dark-theme = true

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[command(version)]
 struct CliArgs {
+    /// Move selection to the previous window in the overlay
     #[arg(short, long)]
     previous: bool,
 }

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -3,7 +3,10 @@ use clap::Parser;
 
 #[derive(Parser)]
 #[command(version)]
-struct CliArgs;
+struct CliArgs {
+    #[arg(short, long)]
+    previous: bool,
+}
 
 #[zbus::proxy(
     default_service = "org.kikibouba.NiriSwitchDaemon",

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -15,6 +15,7 @@ struct CliArgs {
 )]
 trait NiriSwitchDaemon {
     fn activate(&self) -> zbus::Result<()>;
+    fn previous(&self) -> zbus::Result<()>;
 }
 
 fn main() {
@@ -40,8 +41,12 @@ fn main() {
         }
     };
 
-    /* Call activate method on the daemon interface */
-    let result = proxy.activate();
+    /* Call correct method on the daemon interface based on the _args value */
+    let result = if _args.previous {
+        proxy.previous()
+    } else {
+        proxy.activate()
+    };
     match result {
         Ok(_) => (),
         Err(error) => {

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -19,7 +19,7 @@ trait NiriSwitchDaemon {
 }
 
 fn main() {
-    let _args = CliArgs::parse();
+    let args = CliArgs::parse();
 
     /* Connect to D-Bus session */
     let result = zbus::blocking::Connection::session();
@@ -41,8 +41,8 @@ fn main() {
         }
     };
 
-    /* Call correct method on the daemon interface based on the _args value */
-    let result = if _args.previous {
+    /* Call correct method on the daemon interface based on the args value */
+    let result = if args.previous {
         proxy.previous()
     } else {
         proxy.activate()

--- a/src/daemon/dbus.rs
+++ b/src/daemon/dbus.rs
@@ -6,6 +6,7 @@ const DBUS_DAEMON_PATH: &str = "/org/kikibouba/NiriSwitchDaemon";
 
 pub enum DbusEvent {
     Activate,
+    Previous,
 }
 
 struct NiriSwitchDaemonInterface {
@@ -19,6 +20,13 @@ impl NiriSwitchDaemonInterface {
     async fn activate(&self) {
         self.gtk_channel
             .send(DbusEvent::Activate)
+            .await
+            .expect("Sending message should succeed");
+    }
+
+    async fn previous(&self) {
+        self.gtk_channel
+            .send(DbusEvent::Previous)
             .await
             .expect("Sending message should succeed");
     }

--- a/src/daemon/gui/mod.rs
+++ b/src/daemon/gui/mod.rs
@@ -62,7 +62,7 @@ fn sort_windows_by_cached_order(windows: &mut [niri_ipc::Window], store: &Global
 }
 
 /// Handle request to activate the daemon
-async fn handle_daemon_activated(list: &WindowList, store: &GlobalStoreRef) {
+async fn handle_daemon_activated(list: &WindowList, store: &GlobalStoreRef, direction: i32) {
     let window = list
         .root()
         .and_downcast::<gtk4::Window>()
@@ -70,7 +70,7 @@ async fn handle_daemon_activated(list: &WindowList, store: &GlobalStoreRef) {
 
     /* If window is already shown, simply advance the selection */
     if window.is_visible() {
-        list.advance_the_selection();
+        list.advance_the_selection(direction);
         return;
     }
     /* Else reload the listed windows, state might have changed since the last time.
@@ -116,8 +116,8 @@ async fn handle_daemon_activated(list: &WindowList, store: &GlobalStoreRef) {
 async fn handle_dbus_event(event: dbus::DbusEvent, list: &WindowList, store: &GlobalStoreRef) {
     use dbus::DbusEvent::*;
     match event {
-        Activate => handle_daemon_activated(list, store).await,
-        Previous => todo!(),
+        Activate => handle_daemon_activated(list, store, 1).await,
+        Previous => handle_daemon_activated(list, store, -1).await,
     }
 }
 

--- a/src/daemon/gui/mod.rs
+++ b/src/daemon/gui/mod.rs
@@ -72,7 +72,6 @@ async fn handle_previous_selection(list: &WindowList) {
     /* If window is already shown, move back the selection */
     if window.is_visible() {
         list.advance_the_selection(Direction::Forward);
-        return;
     }
     /* Else: do nothing */
 }

--- a/src/daemon/gui/mod.rs
+++ b/src/daemon/gui/mod.rs
@@ -117,6 +117,7 @@ async fn handle_dbus_event(event: dbus::DbusEvent, list: &WindowList, store: &Gl
     use dbus::DbusEvent::*;
     match event {
         Activate => handle_daemon_activated(list, store).await,
+        Previous => todo!(),
     }
 }
 

--- a/src/daemon/gui/mod.rs
+++ b/src/daemon/gui/mod.rs
@@ -15,6 +15,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
 };
+use window_list::Direction;
 use window_list::WindowList;
 
 /* Type aliases to make signatures more readable */
@@ -70,7 +71,7 @@ async fn handle_previous_selection(list: &WindowList) {
 
     /* If window is already shown, move back the selection */
     if window.is_visible() {
-        list.advance_the_selection(-1);
+        list.advance_the_selection(Direction::Forward);
         return;
     }
     /* Else: do nothing */
@@ -85,7 +86,7 @@ async fn handle_daemon_activated(list: &WindowList, store: &GlobalStoreRef) {
 
     /* If window is already shown, simply advance the selection */
     if window.is_visible() {
-        list.advance_the_selection(1);
+        list.advance_the_selection(Direction::Forward);
         return;
     }
     /* Else reload the listed windows, state might have changed since the last time.
@@ -132,7 +133,7 @@ async fn handle_dbus_event(event: dbus::DbusEvent, list: &WindowList, store: &Gl
     use dbus::DbusEvent::*;
     match event {
         Activate => handle_daemon_activated(list, store).await,
-        Previous => handle_previous_selection(list, store).await,
+        Previous => handle_previous_selection(list).await,
     }
 }
 

--- a/src/daemon/gui/mod.rs
+++ b/src/daemon/gui/mod.rs
@@ -71,7 +71,7 @@ async fn handle_previous_selection(list: &WindowList) {
 
     /* If window is already shown, move back the selection */
     if window.is_visible() {
-        list.advance_the_selection(Direction::Forward);
+        list.advance_the_selection(Direction::Backward);
     }
     /* Else: do nothing */
 }

--- a/src/daemon/gui/window_list/mod.rs
+++ b/src/daemon/gui/window_list/mod.rs
@@ -41,8 +41,8 @@ impl WindowList {
         }
     }
 
-    /// Moves the selection in the list by the given direction (positive or negative).
-    /// If the new position goes past the end or before the beginning, the selection wraps around.
+    /// Moves the current selection one step in the given direction
+    /// If the new position goes past the end or before the beginning, the selection wraps around
     pub fn advance_the_selection(&self, direction: Direction) {
         let imp = self.imp();
         let selection_model = get_selection_model(&imp.list);

--- a/src/daemon/gui/window_list/mod.rs
+++ b/src/daemon/gui/window_list/mod.rs
@@ -17,7 +17,6 @@ glib::wrapper! {
         @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
 }
 
-#[derive(PartialEq)]
 pub enum Direction {
     Forward,
     Backward,

--- a/src/daemon/gui/window_list/mod.rs
+++ b/src/daemon/gui/window_list/mod.rs
@@ -42,8 +42,12 @@ impl WindowList {
         let selection_model = get_selection_model(&imp.list);
         let list_store = get_list_store(&imp.list);
 
-        let selected = selection_model.selected();
-        let new_selected = (selected + direction) % list_store.n_items();
+        let selected: i32 = selection_model.selected() as i32;
+        let n_list_items_i32: i32 = list_store.n_items() as i32;
+        let new_selected_raw = selected + direction;
+        let new_selected_i32 =
+            (new_selected_raw % n_list_items_i32 + n_list_items_i32) % n_list_items_i32;
+        let new_selected: u32 = new_selected_i32 as u32;
         imp.list
             .scroll_to(new_selected, gtk4::ListScrollFlags::FOCUS, None);
         imp.list

--- a/src/daemon/gui/window_list/mod.rs
+++ b/src/daemon/gui/window_list/mod.rs
@@ -17,8 +17,7 @@ glib::wrapper! {
         @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
 }
 
-/* Calculate the next index for a looping list, handling wrap-around
- * for negative directions */
+/// Calculate the next index for a looping list, handling wrap-around for negative directions
 fn calculate_wrapped_index(current_index: i32, direction: i32, n_items: i32) -> u32 {
     let new_selected_raw = current_index + direction;
 

--- a/src/daemon/gui/window_list/mod.rs
+++ b/src/daemon/gui/window_list/mod.rs
@@ -37,13 +37,13 @@ impl WindowList {
     }
 
     /// Select the next element in the list, wrap back to the begining if end reached
-    pub fn advance_the_selection(&self) {
+    pub fn advance_the_selection(&self, direction: i32) {
         let imp = self.imp();
         let selection_model = get_selection_model(&imp.list);
         let list_store = get_list_store(&imp.list);
 
         let selected = selection_model.selected();
-        let new_selected = (selected + 1) % list_store.n_items();
+        let new_selected = (selected + direction) % list_store.n_items();
         imp.list
             .scroll_to(new_selected, gtk4::ListScrollFlags::FOCUS, None);
         imp.list

--- a/src/daemon/gui/window_list/mod.rs
+++ b/src/daemon/gui/window_list/mod.rs
@@ -5,7 +5,7 @@ mod window_item;
 
 use gtk4::glib;
 use gtk4::subclass::prelude::*;
-use gtk4::{prelude::*, SingleSelection};
+use gtk4::{SingleSelection, prelude::*};
 use niri_ipc::Window;
 use window_info::WindowInfo;
 
@@ -15,6 +15,12 @@ glib::wrapper! {
     pub struct WindowList(ObjectSubclass<imp::WindowList>)
         @extends gtk4::Widget, gtk4::Box,
         @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
+}
+
+#[derive(PartialEq)]
+pub enum Direction {
+    Forward,
+    Backward,
 }
 
 impl Default for WindowList {
@@ -38,12 +44,17 @@ impl WindowList {
 
     /// Moves the selection in the list by the given direction (positive or negative).
     /// If the new position goes past the end or before the beginning, the selection wraps around.
-    pub fn advance_the_selection(&self, direction: i64) {
+    pub fn advance_the_selection(&self, direction: Direction) {
         let imp = self.imp();
         let selection_model = get_selection_model(&imp.list);
         let list_store = get_list_store(&imp.list);
 
-        let new_selected = i64::from(selection_model.selected()) + direction;
+        let shift = match direction {
+            Direction::Forward => 1,
+            Direction::Backward => -1,
+        };
+
+        let new_selected = i64::from(selection_model.selected()) + shift;
         let new_selected = if new_selected < 0 {
             list_store.n_items() - 1
         } else {


### PR DESCRIPTION
## Changes

- added `previous` method to NiriSwitchDaemon,
- created `enum Direction`,
- modified `daemon/gui/window_list/mod.rs/advance_the_selection` function to accept `enum Direction` parameter,
- described necessary configuration in README.md,