### PR TITLE
Add proper support for Nix with a flake and way to build the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+# Remove result generated with nix
+result 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,50 @@ The [niri-switch](https://aur.archlinux.org/packages/niri-switch) package is ava
 paru -S niri-switch
 ```
 
+### NixOS (Flake)
+
+This repository provides a flake you can use to install the package.
+
+To install it you **must have flake enabled** and your NixOS configuration
+**must be managed with flakes.** See [https://nixos.wiki/wiki/Flakes](https://nixos.wiki/wiki/Flakes) for
+instructions on how to install and enable them on NixOS.
+
+Next, you can add this flake as inputs in `flake.nix` in the repository
+containing your NixOS configuration:
+
+```nix
+inputs = {
+  # ---Snip---
+  niri-switch= {
+    url = "github:Kiki-Bouba-Team/niri-switch";
+    # Optional, by default this flake follows the latest nixpkgs-unstable.
+    # ---
+    # Note that setting this will make it follow your version of nixpkgs, which
+    # can lead to issue if you lock it to nixpkgs stable. If you don't add this
+    # line, the derivation will be bigger, but will work Out Of the Box.
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+  # ---Snip---
+}
+```
+
+Then you can install niri-switch by adding the package provided by this flake in your configuration, for example:
+
+```nix
+{inputs, pkgs, ...}:
+let
+  inherit (pkgs.stdenv.hostPlatform) system;
+in
+{
+    environment.systemPackages = [
+        inputs.niri-switch.${system}.default
+    ];
+}
+```
+
+> [!NOTE]
+> This example only works if you can access `inputs` as an extra argument in your configuration. 
+
 ### Other distributions
 
 On other distributions you will need `cargo` - the Rust build system. It's usually installed via [rustup](https://www.rust-lang.org/tools/install).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The [niri-switch](https://aur.archlinux.org/packages/niri-switch) package is ava
 ```sh
 paru -S niri-switch
 ```
+<details>
+<summary>Installing on NixOS With Flakes</summary>
 
 ### NixOS (Flake)
 
@@ -66,6 +68,8 @@ in
 
 > [!NOTE]
 > This example only works if you can access `inputs` as an extra argument in your configuration. 
+
+</details>
 
 ### Other distributions
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ in
     ];
 }
 ```
-
-> [!NOTE]
-> This example only works if you can access `inputs` as an extra argument in your configuration. 
+This example only works if you can access `inputs` as an extra argument in your configuration. 
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ The [niri-switch](https://aur.archlinux.org/packages/niri-switch) package is ava
 ```sh
 paru -S niri-switch
 ```
-<details>
-<summary>Installing on NixOS With Flakes</summary>
 
 ### NixOS (Flake)
 
 This repository provides a flake you can use to install the package.
+
+<details>
+<summary>Show detailed instructions</summary>
 
 To install it you **must have flake enabled** and your NixOS configuration
 **must be managed with flakes.** See [https://nixos.wiki/wiki/Flakes](https://nixos.wiki/wiki/Flakes) for
@@ -65,7 +66,7 @@ in
     ];
 }
 ```
-This example only works if you can access `inputs` as an extra argument in your configuration. 
+This example only works if you can access `inputs` as an extra argument in your configuration.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ let
 in
 {
     environment.systemPackages = [
-        inputs.niri-switch.${system}.default
+        inputs.niri-switch.packages.${system}.default
     ];
 }
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1759362264,
+        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1760038930,
+        "narHash": "sha256-Oncbh0UmHjSlxO7ErQDM3KM0A5/Znfofj2BSzlHLeVw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0b4defa2584313f3b781240b29d61f6f9f7e0df3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
   outputs = inputs @ {flake-parts, ...}: let
@@ -18,6 +18,11 @@
               rustc
               cargo
               rust-analyzer
+              pkg-config
+              gtk4
+              gtk4-layer-shell
+              gsettings-desktop-schemas
+              glib
             ];
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
   in
     flake-parts.lib.mkFlake {inherit inputs;} ({...}: {
-      systems = ["x86_64-linux" "aarch64-darwin" "x86_64-darwin"];
+      systems = ["x86_64-linux" "aarch64-linux"];
 
       perSystem = {pkgs, ...}: {
         devShells = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+  };
+
+  outputs = inputs @ {flake-parts, ...}: let
+    inherit (cargoToml.package) name version;
+    cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+  in
+    flake-parts.lib.mkFlake {inherit inputs;} ({...}: {
+      systems = ["x86_64-linux" "aarch64-darwin" "x86_64-darwin"];
+
+      perSystem = {pkgs, ...}: {
+        devShells = {
+          # nix develop
+          default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              rustc
+              cargo
+              rust-analyzer
+            ];
+          };
+        };
+
+        packages = {
+          default = pkgs.callPackage ./nix {inherit version name;};
+        };
+      };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,6 @@
   in
     flake-parts.lib.mkFlake {inherit inputs;} ({...}: {
       systems = ["x86_64-linux" "aarch64-linux"];
-
       perSystem = {pkgs, ...}: {
         devShells = {
           # nix develop

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,40 @@
+{
+  rustPlatform,
+  lib,
+  name,
+  version,
+  pkg-config,
+  gtk4,
+  gtk4-layer-shell,
+  gsettings-desktop-schemas,
+  wrapGAppsHook4,
+  glib,
+}:
+rustPlatform.buildRustPackage {
+  inherit version;
+  pname = name;
+  cargoLock.lockFile = ../Cargo.lock;
+  src = lib.cleanSource ../.;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+    glib
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    gtk4-layer-shell
+    gsettings-desktop-schemas
+  ];
+
+  meta = with lib; {
+    description = "A fast task switcher for the niri compositor";
+    license = licenses.gpl3Plus;
+    homepage = "https://github.com/Kiki-Bouba-Team/niri-switch";
+    maintainers = [maintainers.cezaryswitala];
+    mainProgram = "niri-switch";
+    platforms = platforms.linux;
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage {
     license = licenses.gpl3Plus;
     homepage = "https://github.com/Kiki-Bouba-Team/niri-switch";
     maintainers = [maintainers.cezaryswitala];
-    mainProgram = "niri-switch";
+    mainProgram = "niri-switch-daemon";
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
This PR is an improved version of #20, providing an actual flake to build the package in a reproducible way following good practices with Nix and Rust.

The flake also provide a development environment accessible with `nix develop`.